### PR TITLE
fix: Proc.new

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -70,9 +70,9 @@ module AlgoliaSearch
       end
     end
 
-    def initialize(options, block)
+    def initialize(options, &block)
       @options = options
-      instance_exec(&block) if block
+      instance_exec(&block) if block_given?
     end
 
     def attribute(*names, &block)
@@ -199,7 +199,7 @@ module AlgoliaSearch
       raise ArgumentError.new('Options auto_index and auto_remove cannot be set on nested indexes') if options[:auto_index] || options[:auto_remove]
       options[:index_name] = index_name
       @additional_indexes ||= {}
-      @additional_indexes[options] = IndexSettings.new(options, Proc.new)
+      @additional_indexes[options] = IndexSettings.new(options, &block)
     end
 
     def add_slave(index_name, options = {}, &block)
@@ -296,7 +296,7 @@ module AlgoliaSearch
     end
 
     def algoliasearch(options = {}, &block)
-      self.algoliasearch_settings = IndexSettings.new(options, block_given? ? Proc.new : nil)
+      self.algoliasearch_settings = IndexSettings.new(options, &block)
       self.algoliasearch_options = { :type => algolia_full_const_get(model_name.to_s), :per_page => algoliasearch_settings.get_setting(:hitsPerPage) || 10, :page => 1 }.merge(options)
 
       attr_accessor :highlight_result, :snippet_result


### PR DESCRIPTION
# Description
Addressing [Proc with implicit block](https://stackoverflow.com/questions/76658788/ruby-proc-new-in-method-with-implicit-block-no-longer-supported)
Cherry picked from https://github.com/algolia/algoliasearch-rails/pull/377

This would be fixed by version `1.24.1`
Found out we can’t upgrade our `algoliasearch-rails` to `1.22.0` or later (we are using `1.14.1`)
Our Rails version create `<attribute>_changed?` methods that go through `method_missing`
Which end up `Model#respond_to?("<attribute>_changed?")` => `true`
but `Model#method("<attribute>_changed?")` => `raise NameError`
Probably in later Rails versions these methods are actually defined instead of going through method_missing
